### PR TITLE
Updated Wii & Wii U controllers

### DIFF
--- a/pad/nintendo/wiimote/config.json
+++ b/pad/nintendo/wiimote/config.json
@@ -57,7 +57,7 @@
         "cable": null,
         "bluetooth": true,
         "2_4ghz": false,
-        "rumble": "enhanced",
+        "rumble": "standard",
         "digital_to_analog_conversion": null,
         "pc_xinput": false,
         "pc_steaminput": false,

--- a/pad/nintendo/wiiugamepad/config.json
+++ b/pad/nintendo/wiiugamepad/config.json
@@ -93,7 +93,7 @@
         "cable": null,
         "bluetooth": false,
         "2_4ghz": false,
-        "rumble": "enhanced",
+        "rumble": "standard",
         "digital_to_analog_conversion": null,
         "pc_xinput": false,
         "pc_steaminput": false,

--- a/pad/nintendo/wiiupro/config.json
+++ b/pad/nintendo/wiiupro/config.json
@@ -83,7 +83,7 @@
         "cable": null,
         "bluetooth": true,
         "2_4ghz": false,
-        "rumble": "enhanced",
+        "rumble": "standard",
         "digital_to_analog_conversion": null,
         "pc_xinput": false,
         "pc_steaminput": false,


### PR DESCRIPTION
- Fixed rumble type for the following:
  - Wii Remote
  - Wii U Gamepad
  - Wii U Pro Controller